### PR TITLE
Make highlight group defaults

### DIFF
--- a/plugin/desktop_notify.vim
+++ b/plugin/desktop_notify.vim
@@ -1,3 +1,3 @@
 command Notifications :lua require('desktop-notify').open_history()
-hi NotificationsHistoryUrgent guibg=red
-hi NotificationsHistoryWarn guibg=orange
+hi default NotificationsHistoryUrgent guibg=red
+hi default NotificationsHistoryWarn guibg=orange


### PR DESCRIPTION
Hey! Thanks a lot for the plugin! I've wanted to configure the highlight groups because they're not very legible on my system. This PR makes the highlight groups defined by the plugin `default` highlight groups. That way, they can be overridden by the user.